### PR TITLE
feat: Add support for Claude 4 models

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ Prompt:
 
 ## Claude models
 
+### Claude Opus 4.0
+<img src="anthropic__claude-opus-4-0.svg" width="600" alt="Claude Opus 4.0">
+
+### Claude Sonnet 4.0
+<img src="anthropic__claude-sonnet-4-0.svg" width="600" alt="Claude Sonnet 4.0">
+
+### Claude 3.7 Sonnet (2025-02-19)
+<img src="anthropic__claude-3-7-sonnet-20250219.svg" width="600" alt="Claude 3.7 Sonnet (2025-02-19)">
+
+### Claude 3.5 Haiku
+<img src="claude-3.5-haiku.svg" width="600" alt="Claude 3.5 Haiku">
+
 ### Claude 3.5 Sonnet (2024-06-20)
 <img src="claude-3-5-sonnet-20240620.svg" width="600" alt="Claude 3.5 Sonnet (2024-06-20)">
 

--- a/anthropic__claude-3-7-sonnet-20250219.svg
+++ b/anthropic__claude-3-7-sonnet-20250219.svg
@@ -1,0 +1,83 @@
+<svg width="400" height="300" xmlns="http://www.w3.org/2000/svg">
+  <!-- Bicycle -->
+  <g id="bicycle">
+    <!-- Rear wheel -->
+    <circle cx="100" cy="220" r="40" fill="none" stroke="black" stroke-width="2"/>
+    <circle cx="100" cy="220" r="36" fill="none" stroke="black" stroke-width="1"/>
+    <circle cx="100" cy="220" r="5" fill="black"/>
+    <!-- Spokes -->
+    <line x1="100" y1="220" x2="100" y2="184" stroke="black" stroke-width="1"/>
+    <line x1="100" y1="220" x2="100" y2="256" stroke="black" stroke-width="1"/>
+    <line x1="100" y1="220" x2="136" y2="220" stroke="black" stroke-width="1"/>
+    <line x1="100" y1="220" x2="64" y2="220" stroke="black" stroke-width="1"/>
+    <line x1="100" y1="220" x2="125" y2="195" stroke="black" stroke-width="1"/>
+    <line x1="100" y1="220" x2="75" y2="195" stroke="black" stroke-width="1"/>
+    <line x1="100" y1="220" x2="125" y2="245" stroke="black" stroke-width="1"/>
+    <line x1="100" y1="220" x2="75" y2="245" stroke="black" stroke-width="1"/>
+    
+    <!-- Front wheel -->
+    <circle cx="250" cy="220" r="40" fill="none" stroke="black" stroke-width="2"/>
+    <circle cx="250" cy="220" r="36" fill="none" stroke="black" stroke-width="1"/>
+    <circle cx="250" cy="220" r="5" fill="black"/>
+    <!-- Spokes -->
+    <line x1="250" y1="220" x2="250" y2="184" stroke="black" stroke-width="1"/>
+    <line x1="250" y1="220" x2="250" y2="256" stroke="black" stroke-width="1"/>
+    <line x1="250" y1="220" x2="286" y2="220" stroke="black" stroke-width="1"/>
+    <line x1="250" y1="220" x2="214" y2="220" stroke="black" stroke-width="1"/>
+    <line x1="250" y1="220" x2="275" y2="195" stroke="black" stroke-width="1"/>
+    <line x1="250" y1="220" x2="225" y2="195" stroke="black" stroke-width="1"/>
+    <line x1="250" y1="220" x2="275" y2="245" stroke="black" stroke-width="1"/>
+    <line x1="250" y1="220" x2="225" y2="245" stroke="black" stroke-width="1"/>
+    
+    <!-- Frame -->
+    <line x1="100" y1="220" x2="175" y2="150" stroke="black" stroke-width="6"/>
+    <line x1="175" y1="150" x2="250" y2="220" stroke="black" stroke-width="6"/>
+    <line x1="175" y1="150" x2="220" y2="110" stroke="black" stroke-width="6"/>
+    <line x1="220" y1="110" x2="260" y2="160" stroke="black" stroke-width="2"/>
+    
+    <!-- Pedals and chain -->
+    <circle cx="175" cy="150" r="15" fill="none" stroke="black" stroke-width="2"/>
+    <line x1="175" y1="150" x2="190" y2="165" stroke="black" stroke-width="4"/>
+    <line x1="175" y1="150" x2="160" y2="135" stroke="black" stroke-width="4"/>
+    <path d="M100,220 Q120,195 140,190 Q160,185 175,150" fill="none" stroke="black" stroke-width="1" stroke-dasharray="3,3"/>
+    
+    <!-- Handlebars -->
+    <line x1="220" y1="110" x2="200" y2="90" stroke="black" stroke-width="3"/>
+    <line x1="220" y1="110" x2="240" y2="90" stroke="black" stroke-width="3"/>
+    
+    <!-- Seat -->
+    <ellipse cx="175" cy="150" rx="15" ry="5" fill="black"/>
+  </g>
+  
+  <!-- Pelican -->
+  <g id="pelican">
+    <!-- Body -->
+    <ellipse cx="175" cy="105" rx="30" ry="25" fill="#f5f5f5" stroke="black" stroke-width="1"/>
+    
+    <!-- Head -->
+    <circle cx="200" cy="85" r="18" fill="#f5f5f5" stroke="black" stroke-width="1"/>
+    
+    <!-- Eye -->
+    <circle cx="208" cy="80" r="3" fill="black"/>
+    <circle cx="209" cy="79" r="1" fill="white"/>
+    
+    <!-- Beak -->
+    <path d="M210,85 L250,90 L240,100 L210,95 Z" fill="#ffcc00" stroke="black" stroke-width="1"/>
+    <path d="M240,100 L230,110 L210,95 Z" fill="#ff9900" stroke="black" stroke-width="1"/>
+    
+    <!-- Pouch -->
+    <path d="M210,95 Q220,110 210,120 Q200,110 210,95" fill="#ffcc00" stroke="black" stroke-width="1"/>
+    
+    <!-- Wing -->
+    <path d="M175,105 Q160,80 145,105 Q160,120 175,105" fill="#f5f5f5" stroke="black" stroke-width="1"/>
+    
+    <!-- Legs -->
+    <line x1="160" y1="130" x2="160" y2="165" stroke="#ff9900" stroke-width="4"/>
+    <line x1="190" y1="130" x2="190" y2="165" stroke="#ff9900" stroke-width="4"/>
+    
+    <!-- Feet -->
+    <path d="M160,165 L150,170 L160,170 L170,170 Z" fill="#ff9900" stroke="black" stroke-width="1"/>
+    <path d="M190,165 L180,170 L190,170 L200,170 Z" fill="#ff9900" stroke="black" stroke-width="1"/>
+  </g>
+</svg>
+

--- a/anthropic__claude-opus-4-0.svg
+++ b/anthropic__claude-opus-4-0.svg
@@ -1,0 +1,57 @@
+<svg viewBox="0 0 400 300" xmlns="http://www.w3.org/2000/svg">
+  <!-- Bicycle Frame -->
+  <path d="M 150 180 L 220 180 L 250 140 L 200 140 Z" fill="none" stroke="#333" stroke-width="3"/>
+  <line x1="150" y1="180" x2="130" y2="220" stroke="#333" stroke-width="3"/>
+  <line x1="220" y1="180" x2="240" y2="220" stroke="#333" stroke-width="3"/>
+  <line x1="200" y1="140" x2="180" y2="100" stroke="#333" stroke-width="3"/>
+  
+  <!-- Wheels -->
+  <circle cx="130" cy="220" r="30" fill="none" stroke="#333" stroke-width="3"/>
+  <circle cx="240" cy="220" r="30" fill="none" stroke="#333" stroke-width="3"/>
+  <!-- Wheel spokes -->
+  <line x1="130" y1="190" x2="130" y2="250" stroke="#333" stroke-width="1"/>
+  <line x1="100" y1="220" x2="160" y2="220" stroke="#333" stroke-width="1"/>
+  <line x1="240" y1="190" x2="240" y2="250" stroke="#333" stroke-width="1"/>
+  <line x1="210" y1="220" x2="270" y2="220" stroke="#333" stroke-width="1"/>
+  
+  <!-- Pedals -->
+  <circle cx="185" cy="180" r="15" fill="none" stroke="#333" stroke-width="2"/>
+  <line x1="185" y1="165" x2="185" y2="175" stroke="#333" stroke-width="3"/>
+  <line x1="185" y1="185" x2="185" y2="195" stroke="#333" stroke-width="3"/>
+  
+  <!-- Handlebars -->
+  <line x1="180" y1="100" x2="170" y2="90" stroke="#333" stroke-width="3"/>
+  <line x1="180" y1="100" x2="190" y2="90" stroke="#333" stroke-width="3"/>
+  <circle cx="170" cy="90" r="4" fill="#333"/>
+  <circle cx="190" cy="90" r="4" fill="#333"/>
+  
+  <!-- Seat -->
+  <ellipse cx="150" cy="135" rx="20" ry="8" fill="#8B4513"/>
+  
+  <!-- Pelican Body -->
+  <ellipse cx="160" cy="120" rx="35" ry="40" fill="white" stroke="#333" stroke-width="2"/>
+  
+  <!-- Pelican Head -->
+  <circle cx="190" cy="80" r="20" fill="white" stroke="#333" stroke-width="2"/>
+  
+  <!-- Pelican Beak -->
+  <path d="M 205 80 L 235 85 L 235 90 L 220 95 Q 210 92 205 85 Z" fill="#FFA500" stroke="#333" stroke-width="1"/>
+  <!-- Pouch -->
+  <path d="M 205 85 Q 210 92 220 95 L 215 105 Q 205 100 205 85" fill="#FFD700" stroke="#333" stroke-width="1"/>
+  
+  <!-- Pelican Eye -->
+  <circle cx="195" cy="75" r="3" fill="#333"/>
+  <circle cx="196" cy="74" r="1" fill="white"/>
+  
+  <!-- Pelican Wings -->
+  <ellipse cx="140" cy="115" rx="20" ry="35" fill="white" stroke="#333" stroke-width="2" transform="rotate(-20 140 115)"/>
+  <ellipse cx="180" cy="115" rx="20" ry="35" fill="white" stroke="#333" stroke-width="2" transform="rotate(20 180 115)"/>
+  
+  <!-- Pelican Legs on pedals -->
+  <line x1="155" y1="145" x2="175" y2="170" stroke="#FFA500" stroke-width="4"/>
+  <line x1="165" y1="145" x2="195" y2="190" stroke="#FFA500" stroke-width="4"/>
+  
+  <!-- Pelican Feet -->
+  <path d="M 172 170 L 170 175 M 175 170 L 175 175 M 178 170 L 180 175" stroke="#FFA500" stroke-width="2"/>
+  <path d="M 192 190 L 190 195 M 195 190 L 195 195 M 198 190 L 200 195" stroke="#FFA500" stroke-width="2"/>
+</svg>

--- a/anthropic__claude-sonnet-4-0.svg
+++ b/anthropic__claude-sonnet-4-0.svg
@@ -1,0 +1,68 @@
+<svg width="400" height="300" viewBox="0 0 400 300" xmlns="http://www.w3.org/2000/svg">
+  <!-- Background -->
+  <rect width="400" height="300" fill="#87CEEB"/>
+  
+  <!-- Bicycle wheels -->
+  <circle cx="100" cy="220" r="35" fill="none" stroke="#333" stroke-width="3"/>
+  <circle cx="250" cy="220" r="35" fill="none" stroke="#333" stroke-width="3"/>
+  
+  <!-- Wheel spokes -->
+  <g stroke="#666" stroke-width="1">
+    <line x1="100" y1="185" x2="100" y2="255"/>
+    <line x1="65" y1="220" x2="135" y2="220"/>
+    <line x1="250" y1="185" x2="250" y2="255"/>
+    <line x1="215" y1="220" x2="285" y2="220"/>
+  </g>
+  
+  <!-- Bicycle frame -->
+  <g stroke="#444" stroke-width="4" fill="none">
+    <line x1="100" y1="220" x2="175" y2="180"/>
+    <line x1="175" y1="180" x2="220" y2="200"/>
+    <line x1="220" y1="200" x2="250" y2="220"/>
+    <line x1="175" y1="180" x2="175" y2="210"/>
+    <line x1="175" y1="210" x2="250" y2="220"/>
+  </g>
+  
+  <!-- Pedals and chain -->
+  <circle cx="175" cy="210" r="8" fill="#666"/>
+  <line x1="165" y1="210" x2="185" y2="210" stroke="#333" stroke-width="2"/>
+  
+  <!-- Handlebars -->
+  <line x1="220" y1="200" x2="230" y2="190" stroke="#444" stroke-width="4"/>
+  <line x1="225" y1="185" x2="235" y2="185" stroke="#444" stroke-width="3"/>
+  
+  <!-- Pelican body -->
+  <ellipse cx="180" cy="140" rx="40" ry="25" fill="#f0f0f0"/>
+  
+  <!-- Pelican neck -->
+  <ellipse cx="200" cy="110" rx="12" ry="20" fill="#f0f0f0"/>
+  
+  <!-- Pelican head -->
+  <ellipse cx="210" cy="85" rx="18" ry="15" fill="#f0f0f0"/>
+  
+  <!-- Pelican beak upper -->
+  <path d="M 228 85 Q 270 80 275 85 Q 270 90 228 92 Z" fill="#FFA500"/>
+  
+  <!-- Pelican beak lower (pouch) -->
+  <path d="M 228 92 Q 265 95 270 100 Q 265 105 250 108 Q 235 105 228 100 Z" fill="#FFB84D"/>
+  
+  <!-- Pelican eye -->
+  <circle cx="215" cy="80" r="3" fill="#000"/>
+  <circle cx="216" cy="79" r="1" fill="#fff"/>
+  
+  <!-- Pelican wing -->
+  <ellipse cx="170" cy="135" rx="25" ry="15" fill="#e8e8e8"/>
+  <path d="M 150 135 Q 160 130 170 135 Q 160 140 150 135" fill="#ddd"/>
+  
+  <!-- Pelican legs on pedals -->
+  <line x1="175" y1="165" x2="170" y2="200" stroke="#FFA500" stroke-width="3"/>
+  <line x1="185" y1="165" x2="180" y2="200" stroke="#FFA500" stroke-width="3"/>
+  
+  <!-- Pelican feet on pedals -->
+  <ellipse cx="168" cy="202" rx="6" ry="3" fill="#FFA500"/>
+  <ellipse cx="182" cy="202" rx="6" ry="3" fill="#FFA500"/>
+  
+  <!-- Wing holding handlebars -->
+  <ellipse cx="215" cy="150" rx="15" ry="8" fill="#e8e8e8" transform="rotate(-30 215 150)"/>
+  <line x1="225" y1="145" x2="230" y2="185" stroke="#e8e8e8" stroke-width="8"/>
+</svg>

--- a/claude-3.5-haiku.svg
+++ b/claude-3.5-haiku.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <!-- Bicycle Frame -->
+  <path d="M150 200 L100 250 Q150 270 200 250 L180 200" fill="none" stroke="gray" stroke-width="5"/>
+  
+  <!-- Wheels -->
+  <circle cx="100" cy="250" r="40" fill="none" stroke="black" stroke-width="3"/>
+  <circle cx="300" cy="250" r="40" fill="none" stroke="black" stroke-width="3"/>
+  
+  <!-- Wheel Spokes -->
+  <line x1="100" y1="210" x2="100" y2="290" stroke="black" stroke-width="2"/>
+  <line x1="60" y1="250" x2="140" y2="250" stroke="black" stroke-width="2"/>
+  <line x1="300" y1="210" x2="300" y2="290" stroke="black" stroke-width="2"/>
+  <line x1="260" y1="250" x2="340" y2="250" stroke="black" stroke-width="2"/>
+  
+  <!-- Pelican Body -->
+  <path d="M180 150 Q200 100 230 120 Q260 140 250 170 Q240 200 220 190" fill="#87CEEB" stroke="black" stroke-width="2"/>
+  
+  <!-- Pelican Beak -->
+  <path d="M230 120 L250 110 L260 130 Z" fill="orange" stroke="black" stroke-width="2"/>
+  
+  <!-- Pelican Eye -->
+  <circle cx="220" cy="130" r="5" fill="white" stroke="black" stroke-width="2"/>
+  
+  <!-- Pelican Wing -->
+  <path d="M220 190 Q240 170 250 180" fill="none" stroke="black" stroke-width="2"/>
+</svg>

--- a/generate-svgs.sh
+++ b/generate-svgs.sh
@@ -7,6 +7,10 @@ models=(
     "gpt-4o"
     "o1-preview"
     "o1-mini"
+    "anthropic/claude-opus-4-0"
+    "anthropic/claude-sonnet-4-0"
+    "anthropic/claude-3-7-sonnet-20250219"
+    "claude-3.5-haiku"
     "claude-3-5-sonnet-20240620"
     "claude-3-5-sonnet-20241022"
     "claude-3-haiku-20240307"
@@ -30,11 +34,11 @@ mkdir -p failures
 
 # Loop through each model
 for model in "${models[@]}"; do
-    output_file="$model.svg"
-    # Replace any : in that with -
-    output_file="${output_file//:/-}"
+    # Replace / with __ and : with - for filenames
+    output_file="${model//\//__}"
+    output_file="${output_file//:/-}.svg"
     timestamp=$(date '+%Y%m%d%H%M')
-    failure_file="failures/$model.$timestamp.txt"
+    failure_file="failures/${output_file%.svg}.$timestamp.txt"
     
     # Check if file already exists
     if [ ! -f "$output_file" ]; then


### PR DESCRIPTION
Updates the `generate-svgs.sh` script to add new models, and adds the generated images aswell.

### Model additions:

* Added four new models to the `models` array: 
    * `anthropic/claude-opus-4-0`
    * `anthropic/claude-sonnet-4-0`
    * `anthropic/claude-3-7-sonnet-20250219`
    * `claude-3.5-haiku`
* The models that start with `anthropic/*` don't have an alias yet. 
* To support namespaced models  (i.e. `anthropic/*`), the filename generation was updated to replace `/` with `__`.

